### PR TITLE
First tests for TCString

### DIFF
--- a/modules/core/src/TCString.ts
+++ b/modules/core/src/TCString.ts
@@ -68,7 +68,7 @@ export class TCString implements Encoder<TCModel> {
       const segment: string = segments[i];
       let encoder: Encoder<TCModel>;
 
-      // fist is always core
+      // first is always core
       if ( i === 0 ) {
 
         encoder = new segMap.core();
@@ -76,9 +76,10 @@ export class TCString implements Encoder<TCModel> {
       } else {
 
         // first char will contain 6 bits, we only need the first 3
-        const segTypeBits: string = base64Url.decode(segment.charAt(0));
-        const segType: string = intEnc.decode(segTypeBits.substr(0, BitLength.segmentType)).toString();
-
+        const firstCharBits: string = base64Url.decode(segment.charAt(0));
+        const segTypeBits: string = firstCharBits.substr(0, BitLength.segmentType);
+        const segType: string = intEnc.decode(segTypeBits).toString();
+        
         encoder = new segMap[SegmentType[segType]]();
 
       }

--- a/modules/core/src/encoder/CoreTCEncoder.ts
+++ b/modules/core/src/encoder/CoreTCEncoder.ts
@@ -31,7 +31,12 @@ export class CoreTCEncoder implements Encoder<TCModel> {
       const numBits: number = BitLength[key];
       const encoder: Encoder<TCModelPropType> = new this.encMap[key]() as Encoder<TCModelPropType>;
 
-      bitField += encoder.encode(value, numBits);
+      try {
+        bitField += encoder.encode(value, numBits);
+      } catch (err) {
+        err.message = `Error while trying to encode '${key}': ${err.message}`;
+        throw err;
+      }
 
     });
 
@@ -53,8 +58,8 @@ export class CoreTCEncoder implements Encoder<TCModel> {
     encodeSequence.forEach((key: string): void => {
 
       const encoder: Encoder<TCModelPropType> = new this.encMap[key]() as Encoder<TCModelPropType>;
-
-      tcModel[key] = encoder.decode(bitField.substr(bStringIdx, BitLength[key]));
+      const bits = bitField.substr(bStringIdx, BitLength[key]);
+      tcModel[key] = encoder.decode(bits);
 
       if (BitLength[key]) {
 

--- a/modules/core/src/encoder/PublisherTCEncoder.ts
+++ b/modules/core/src/encoder/PublisherTCEncoder.ts
@@ -4,6 +4,8 @@ import {
   EncoderMap,
   BitLength,
   Base64Url,
+  IntEncoder,
+  SegmentType,
 
 } from '.';
 
@@ -22,9 +24,12 @@ export class PublisherTCEncoder implements Encoder<TCModel> {
 
   public encode(tcModel: TCModel): string {
 
+    const intEnc: IntEncoder = new IntEncoder();
     const pubFieldSequence: PublisherFieldSequence = new PublisherFieldSequence();
     const encodeSequence: string[] = pubFieldSequence[tcModel.version.toString()];
-    let bitField = '';
+    
+    // first encode the segment type
+    let bitField: string = intEnc.encode(SegmentType.publisherTC, BitLength.segmentType);
 
     encodeSequence.forEach((key: string): void => {
 

--- a/modules/core/test/TCString.test.ts
+++ b/modules/core/test/TCString.test.ts
@@ -6,8 +6,101 @@ import {
   GVL,
 } from '../src';
 
+type MinimalModelOptions = {
+  versions?: Number
+}
+
+const doEncode = (options = {}) => {
+
+  const tcString = new TCString();
+  const model = getMinimalModel(options);
+  return tcString.encode(model);
+
+}
+
+const truncDate = (date: Date) => Math.round(date.getTime() / 100) * 100;
+
+const getMinimalModel = (customOptions: MinimalModelOptions = {}) => {
+  const options = {
+    version: 2,
+    ...customOptions
+  };
+
+  const vendorlistJson = require('../dev/vendorlist.json');
+  const gvl: GVL = new GVL(vendorlistJson);
+  
+  const model = new TCModel(gvl);
+  model.cmpId = 123;
+  model.cmpVersion = 1;
+  model.consentLanguage = 'en';
+  model.version = options.version;
+  return model;
+
+};
+
+const compareModels = (actual: TCModel, expected: TCModel) => {
+  
+  const compareProp = (propName: string, transform = _ => _) => {
+    
+    const actualValue = transform(actual[propName]);
+    const expectedValue = transform(expected[propName]);
+    expect(actualValue, `Error while comparing '${propName}'`).to.eq(expectedValue);
+
+  }
+
+  compareProp('cmpId');
+  compareProp('cmpVersion');
+  compareProp('consentLanguage');
+  compareProp('consentScreen');
+  compareProp('created', truncDate);
+  compareProp('lastUpdated', truncDate);
+  compareProp('policyVersion');
+  compareProp('useNonStandardStacks');
+  compareProp('version');
+
+}
+
 describe('TCString', (): void => {
 
-  // soon...
+  describe('.encode(tcModel)', (): void => {
+    
+    it('does not throw if a valid TCModel is passed', (): void => {
+      
+      expect(doEncode).not.to.throw();
+
+    });
+
+    it('returns a string with 4 segments when TCModel version is 2', () => {
+
+      const encodedString = doEncode();
+
+      expect(encodedString.split('.')).to.be.lengthOf(4);
+
+    });
+
+    xit('WIP: currently fails. returns a string with only 1 segment when tCModel version is 1', () => {
+
+      const encodedString = doEncode({ version: 1 });
+
+      expect(encodedString.split('.')).to.be.lengthOf(1);
+
+    });
+
+  });
+
+  describe('.decode(encodedString)', () => {
+
+    it('returns an equivalent model if encoded and decoded', () => {
+
+      const tcString = new TCString();
+      const model = getMinimalModel();
+      const encodedString = tcString.encode(model);
+      const decodedModel = tcString.decode(encodedString);
+      
+      compareModels(decodedModel, model);
+
+    });
+
+  });
 
 });


### PR DESCRIPTION
Here the first tests for `TCString` module.

The PublisherTC segment did not add the segment type so I fixed it.

While part of the core code should be compatible with TCFv1, `TCString.encode` with version 1 still creates a 4-segments-string so I commented the test.